### PR TITLE
Change the hook priority of pushButton and releaseButton to INT_MIN

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -417,8 +417,8 @@ class $modify(CCScheduler) {
 
 class $modify(PlayerObject) {
 	static void onModify(auto & self) {
-		self.setHookPriority("PlayerObject::pushButton", 50000);
-		self.setHookPriority("PlayerObject::releaseButton", 50000);
+		self.setHookPriority("PlayerObject::pushButton", INT_MIN);
+		self.setHookPriority("PlayerObject::releaseButton", INT_MIN);
 	}
 
 	void pushButton(PlayerButton button) {


### PR DESCRIPTION
From what you have told me, your hooks run twice, the first time they do nothing, and the second time they actually run. If the hook priority is high, it will cause other functions to run first, then run your function. Since your hook priority is high, and you make the functions run twice, you call other mods' functions twice as well.
If you set the priority to INT_MIN (i.e. this function is the very first function to run and calls all other functions), the first time your function does nothing it doesn't call anything else, and the second time it runs it calls everything with a higher hook priority.
This results in your function running other mods' functions only once.
I don't entirely understand your code, so it may be that there are problems with setting it to INT_MIN that I have not foreseen, but I tested it and it seems to work fine for me.
