### PR TITLE
fixed clicks after death causing first frame jump when respawning

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,7 +258,11 @@ class $modify(GJBaseGameLayer) {
 			const int stepCount = std::round(std::max(1.0, ((modifiedDelta * 60.0) / std::min(1.0f, timewarp)) * 4)); // not sure if this is different from (delta * 240) / timewarp
 
 			if (modifiedDelta > 0.0) updateInputQueueAndTime(stepCount);
-			else skipUpdate = true;
+			else {
+				skipUpdate = true;
+				firstFrame = true;
+				skipUpdate = true;
+			}
 		}
 		
 		return modifiedDelta;


### PR DESCRIPTION
The player isDead flag doesn't work as expected. It only returns true before the level starts. This fix effectively makes the mod treat the player as dead if there is a delta time of 0, which should normally only be the case if the player is dead and waiting to respawn.