### PR TITLE
Click after death fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,7 +258,11 @@ class $modify(GJBaseGameLayer) {
 			const int stepCount = std::round(std::max(1.0, ((modifiedDelta * 60.0) / std::min(1.0f, timewarp)) * 4)); // not sure if this is different from (delta * 240) / timewarp
 
 			if (modifiedDelta > 0.0) updateInputQueueAndTime(stepCount);
-			else skipUpdate = true;
+			else {
+				skipUpdate = true;
+				firstFrame = true;
+				skipUpdate = true;
+			}
 		}
 		
 		return modifiedDelta;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -259,9 +259,8 @@ class $modify(GJBaseGameLayer) {
 
 			if (modifiedDelta > 0.0) updateInputQueueAndTime(stepCount);
 			else {
-				skipUpdate = true;
+				enableInput = true;
 				firstFrame = true;
-				skipUpdate = true;
 			}
 		}
 		


### PR DESCRIPTION
I am creating a new pull request with this fix. One user has claimed to have issues, but I can't verify nor reproduce the issues. Still unsure if they are even using the correct code, what other mods they have, what their refresh rate is, etc. I have put thousands of attempts into extreme demons / dozens of hours in practice / normal mode with this fix in a local copy of the mod, and never had a single issue. 

Also, it was mentioned that certain types of lag spikes could trigger this code, but what types of lag spikes are those? If getModifiedDelta simply returns the delta time from the current -> previous simulation frame, what scenario would cause it to be 0? Any sort of lag spike should just _increase_ the delta, if anything. 

Anyways, if there do happen to be rare issues, I think it's more beneficial to tackle those when they are reported. The current state of CBF makes practice mode almost impossible to use, as, quite literally, 50-75% of the time you instantly die due to an erroneous queued jump.