### PR TITLE
Make custom keybinds optional on windows

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-	"geode": "4.4.0",
+	"geode": "4.9.0",
 	"gd": {
 		"win": "2.2074",
 		"android": "2.2074",
@@ -13,8 +13,8 @@
 	"description": "Allows inputs to register between frames.",
 	"dependencies": {
 		"geode.custom-keybinds": {
-			"importance": "required",
-			"version": ">=v1.10.0",
+			"importance": "suggested",
+			"version": ">=v1.11.0",
 			"platforms": ["win"]
 		}
 	},

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -1,5 +1,4 @@
 #include "includes.hpp"
-#include <geode.custom-keybinds/include/OptionalAPI.hpp>
 
 TimestampType getCurrentTimestamp() {
 	LARGE_INTEGER t;
@@ -93,14 +92,11 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				else return 0;
 
 				queueInMainThread([inputState]() {
-					if (useCustomKeybinds) {
-						keybinds::InvokeBindEventV2("robtop.geometry-dash/jump-p2", inputState).post();
-					} else {
-						auto* pl = PlayLayer::get();
-						if (pl == nullptr || pl != CCScene::get()->getChildByType<PlayLayer*>(0)) return;
-						pl->queueButton(1, inputState, true);
-						pl->m_uiLayer->m_p2Jumping = inputState;
-					}
+					auto* pl = PlayLayer::get();
+					// check for fake playlayers
+					if (pl == nullptr || pl != CCScene::get()->getChildByType<PlayLayer*>(0)) return;
+					pl->queueButton(1, inputState, true);
+					pl->m_uiLayer->m_p2Jumping = inputState;
 				});
 			}
 

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -1,5 +1,5 @@
 #include "includes.hpp"
-#include <geode.custom-keybinds/include/Keybinds.hpp>
+#include <geode.custom-keybinds/include/OptionalAPI.hpp>
 
 TimestampType getCurrentTimestamp() {
 	LARGE_INTEGER t;
@@ -92,7 +92,11 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				else if (flags & RI_MOUSE_BUTTON_2_UP) inputState = Release;
 				else return 0;
 
-				queueInMainThread([inputState]() {keybinds::InvokeBindEvent("robtop.geometry-dash/jump-p2", inputState).post();});
+				if (useCustomKeybinds) {
+					queueInMainThread([inputState]() {
+						keybinds::InvokeBindEventV2("robtop.geometry-dash/jump-p2", inputState).post();
+					});
+				}
 			}
 
 			QueryPerformanceCounter(&time); // dont call on mouse move events

--- a/src/windows.cpp
+++ b/src/windows.cpp
@@ -92,11 +92,16 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				else if (flags & RI_MOUSE_BUTTON_2_UP) inputState = Release;
 				else return 0;
 
-				if (useCustomKeybinds) {
-					queueInMainThread([inputState]() {
+				queueInMainThread([inputState]() {
+					if (useCustomKeybinds) {
 						keybinds::InvokeBindEventV2("robtop.geometry-dash/jump-p2", inputState).post();
-					});
-				}
+					} else {
+						auto* pl = PlayLayer::get();
+						if (pl == nullptr || pl != CCScene::get()->getChildByType<PlayLayer*>(0)) return;
+						pl->queueButton(1, inputState, true);
+						pl->m_uiLayer->m_p2Jumping = inputState;
+					}
+				});
 			}
 
 			QueryPerformanceCounter(&time); // dont call on mouse move events

--- a/src/windows.hpp
+++ b/src/windows.hpp
@@ -14,6 +14,7 @@ extern HANDLE hMutex;
 extern LPVOID pBuf;
 
 extern bool linuxNative;
+extern bool useCustomKeybinds;
 
 inline LARGE_INTEGER largeFromTimestamp(TimestampType t) {
 	LARGE_INTEGER res;


### PR DESCRIPTION
Custom Keybinds v1.11.0 adds an optional api, use it to get the default binds (which is the only thing CBF used CK for)